### PR TITLE
Adding business card metadata type and value

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,8 @@ export const claimsMetadata: ClaimsMetadataSummary = {
     context: [
       {
         ProofOfMobilePhoneNumberCredential: 'https://identity.jolocom.com/terms/ProofOfMobilePhoneNumberCredential',
-        telephone: "http://schema.org/telephone"
+        schema: "http://schema.org/",
+        telephone: "schema:telephone"
       }
     ]
   },
@@ -64,5 +65,21 @@ export const claimsMetadata: ClaimsMetadataSummary = {
         country: "schema:addressCountry"
       }
     ]
+  },
+  businessCard: {
+    type: ['Credential', 'ProofOfBusinessCardCredential'],
+    name: 'Business Card',
+    context: [
+        {
+          ProofOfBusinessCardCredential: 'https://identity.jolocom.com/terms/ProofOfBusinessCardCredential',
+          schema: "http://schema.org/",
+          familyName: "schema:familyName",
+          givenName: "schema:givenName",
+          email: "schema:email",
+          telephone: "schema:telephone",
+          legalCompanyName: "schema:legalName"
+        }
+    ]
+
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -50,10 +50,21 @@ export interface PostalAddressClaimMetadata extends BaseMetadata {
   }
 }
 
+export interface BusinessCardClaimMetadata extends BaseMetadata {
+  claimInterface?: {
+    givenName: string
+    familyName: string
+    email: string
+    telephone: string
+    legalCompanyName: "schema:legalName"
+  }
+}
+
 export interface ClaimsMetadataSummary {
   emailAddress: EmailClaimMetadata
   mobilePhoneNumber: MobilePhoneNumberClaimMetadata
   name: NameClaimMetadata
   publicProfile: PublicProfileClaimMetadata
   postalAddress: PostalAddressClaimMetadata
+  businessCard: BusinessCardClaimMetadata
 }


### PR DESCRIPTION
Wallet 2.0 requires support for the Business card as a separate self-issued credential